### PR TITLE
Adds bias terms

### DIFF
--- a/slot_attention/slot_attention.py
+++ b/slot_attention/slot_attention.py
@@ -12,9 +12,9 @@ class SlotAttention(nn.Module):
         self.slots_mu = nn.Parameter(torch.randn(1, 1, dim))
         self.slots_sigma = nn.Parameter(torch.randn(1, 1, dim))
 
-        self.to_q = nn.Linear(dim, dim, bias = False)
-        self.to_k = nn.Linear(dim, dim, bias = False)
-        self.to_v = nn.Linear(dim, dim, bias = False)
+        self.to_q = nn.Linear(dim, dim, bias = True)
+        self.to_k = nn.Linear(dim, dim, bias = True)
+        self.to_v = nn.Linear(dim, dim, bias = True)
 
         self.gru = nn.GRUCell(dim, dim)
 


### PR DESCRIPTION
I've spent some time replicating the results of the original paper, and in my experience these bias terms are crucial.

Without:
![image](https://user-images.githubusercontent.com/206013/89522057-ddad7500-d7e0-11ea-8190-d30624ca5c37.png)

With:
![image](https://user-images.githubusercontent.com/206013/89522072-e43bec80-d7e0-11ea-8f8d-88d6461da297.png)

loss with and without
![image](https://user-images.githubusercontent.com/206013/89522291-44cb2980-d7e1-11ea-83ea-1180f1736600.png)
