### PR TITLE
fix an error when fp16 is used

### DIFF
--- a/slot_attention/slot_attention.py
+++ b/slot_attention/slot_attention.py
@@ -34,13 +34,13 @@ class SlotAttention(nn.Module):
         self.norm_pre_ff = nn.LayerNorm(dim)
 
     def forward(self, inputs, num_slots = None):
-        b, n, d, device = *inputs.shape, inputs.device
+        b, n, d = inputs.shape
         n_s = num_slots if num_slots is not None else self.num_slots
         
         mu = self.slots_mu.expand(b, n_s, -1)
         sigma = self.slots_logsigma.exp().expand(b, n_s, -1)
 
-        slots = mu + sigma * torch.randn(mu.shape, device = device)
+        slots = mu + sigma * torch.randn_like(mu)
 
         inputs = self.norm_input(inputs)        
         k, v = self.to_k(inputs), self.to_v(inputs)
@@ -53,7 +53,7 @@ class SlotAttention(nn.Module):
 
             dots = torch.einsum('bid,bjd->bij', q, k) * self.scale
             attn = dots.softmax(dim=1) + self.eps
-            attn = attn / attn.sum(dim=-1, keepdim=True)
+            attn = attn / attn.sum(dim=-1, keepdim=True).to(attn)
 
             updates = torch.einsum('bjd,bij->bid', v, attn)
 


### PR DESCRIPTION
two points:
1. the device is not required since `to` will complete all related things (shape & device);
2. When I use half type (fp16), line 56 meets errors since the type of `attn. sum()` is float32, I'm not sure why this happen, but the method `to` of Tensor could fix it no matter whether `float32` or `float16` is used.